### PR TITLE
fix: rendered more hooks than previous error

### DIFF
--- a/src/story-decorator.tsx
+++ b/src/story-decorator.tsx
@@ -5,12 +5,14 @@ import { extractLanguageFromFilename } from './components/utils';
 import { LIVE_EXAMPLES_ADDON_ID } from './config';
 
 export const decorator = (storyFn: StoryFn, context: StoryContext) => {
+    const story = storyFn();
+
     if (
         context.viewMode !== 'docs' ||
         context.parameters.defaultCanvas ||
         addons.getConfig()[LIVE_EXAMPLES_ADDON_ID].defaultCanvas
     )
-        return storyFn();
+        return story;
 
     const { live = true, expanded = false, storySource, scope } = context.parameters;
 


### PR DESCRIPTION
Fixes #4 by always running the `storyFn` function.