### PR TITLE
fix: fixed share path

### DIFF
--- a/src/components/Example.tsx
+++ b/src/components/Example.tsx
@@ -334,8 +334,8 @@ export const Example: FC<ExampleProps & { example?: number }> = ({
                                 icon={ShareMIcon}
                                 onClick={() => {
                                     handleCopy(
-                                        `${
-                                            window.parent.location.origin
+                                        `${window.parent.location.origin}${
+                                            window.parent.location.pathname
                                         }?path=${sandboxPath}/code=${encodeURIComponent(code)}`,
                                     );
                                     dispatchCustomEvent(CUSTOM_EVENTS.SHARE);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.2--canary.13.36cfe6e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-live-examples@2.0.2--canary.13.36cfe6e.0
  # or 
  yarn add storybook-addon-live-examples@2.0.2--canary.13.36cfe6e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
